### PR TITLE
chore(hive): use temp eest branch

### DIFF
--- a/.github/workflows/hive-devnet-3.yaml
+++ b/.github/workflows/hive-devnet-3.yaml
@@ -69,7 +69,7 @@ env:
   S3_PUBLIC_URL: https://hive.ethpandaops.io/#/test/fusaka-devnet-3/
   INSTALL_RCLONE_VERSION: v1.68.2
   EEST_BUILD_ARG_FIXTURES: https://github.com/ethereum/execution-spec-tests/releases/download/fusaka-devnet-3%40v1.0.0/fixtures_fusaka-devnet-3.tar.gz
-  EEST_BUILD_ARG_BRANCH: fusaka-devnet-3
+  EEST_BUILD_ARG_BRANCH: hive
   # Flags used for all simulators
   GLOBAL_EXTRA_FLAGS: >-
     --client.checktimelimit=180s


### PR DESCRIPTION
Consume is broken on EEST main/fusaka-devnet-3 branches. This branch can be used a workaround for the next week.