### PR TITLE
disable tx gossip for rbuilder

### DIFF
--- a/ansible/inventories/devnet-3/host_vars/mev-relay-1.yaml
+++ b/ansible/inventories/devnet-3/host_vars/mev-relay-1.yaml
@@ -184,7 +184,7 @@ reth_container_command_extra_args:
   - --builder.gaslimit=45000000
   - --engine.persistence-threshold=0
   - --engine.memory-block-buffer-target=0
-  - --txpool.no-local-transactions-propagation
+  - --disable-tx-gossip
   - --rpc.eth-proof-window=3
 reth_container_pull: true
 


### PR DESCRIPTION
`--txpool.no-local-transactions-propagation` does not allow locally sent txs to be propagated to other peers but at the same time doesn't allow them to be streamed by eth_newPendingTransactions. 
A new flag was introduced in reth to disable tx gossip here: https://github.com/paradigmxyz/reth/pull/17724, we can use it to disable tx gossip and at the same time allow eth_newPendingTransactions to stream tx.