### PR TITLE
Enable tx gossip for rbuilder

### DIFF
--- a/ansible/inventories/devnet-3/host_vars/mev-relay-1-arm.yaml
+++ b/ansible/inventories/devnet-3/host_vars/mev-relay-1-arm.yaml
@@ -189,7 +189,6 @@ reth_container_command_extra_args:
   - --builder.gaslimit=45000000
   - --engine.persistence-threshold=0
   - --engine.memory-block-buffer-target=0
-  - --disable-tx-gossip
   - --rpc.eth-proof-window=3
 reth_container_pull: true
 


### PR DESCRIPTION
We can enable it when we want to do private mempool testing.