### PR TITLE
Increase simulation threads for rbuilder

### DIFF
--- a/ansible/inventories/devnet-5/host_vars/mev-relay-1-arm.yaml
+++ b/ansible/inventories/devnet-5/host_vars/mev-relay-1-arm.yaml
@@ -233,6 +233,8 @@ reth_rbuilder_config: |
 
   subsidy = "1"
 
+  simulation_threads=4
+
   [[relays]]
   name = "flashbots"
   url = "http://0xa55c1285d84ba83a5ad26420cd5ad3091e49c55a813eee651cd467db38a8c8e63192f47955e9376f6b42f6d190571cb5@mev-relay-1-arm.{{ network_server_subdomain }}:9062"


### PR DESCRIPTION
Could potentially increase block building efficiency by having more simulation threads.